### PR TITLE
Updating with class-specific volume mount

### DIFF
--- a/hub.js
+++ b/hub.js
@@ -172,7 +172,7 @@ server.get('/login', (req, res) => {
     "Env": [`VS_USER=${user}`],
     "ExposedPorts": {"8000/tcp":{}},
     "HostConfig": {
-      "Binds": [`/home/${user}:/home/${user}`],
+      "Binds": [`sum2022:/home`],
       "PortBindings": {
         "8000/tcp": [
           {


### PR DESCRIPTION
Created a summer-specific volume mount with home folders copied; we will need to keep in mind that we need to build _in the appropriate volume mount folder_ when creating new classes. (This more of a note for me, @dluman.) 

Users shouldn't see a difference, but this will affect partitioning in the future should we need to increase available space on a cluster-allocated storage. I will create a ticket to to pay attention when we migrate this.