### PR TITLE
Adding registry removal back in after event emit

### DIFF
--- a/hub.js
+++ b/hub.js
@@ -262,6 +262,7 @@ app.on('upgrade', (req, socket, head) => {
     registry[user].params.sockets--;
     if(registry[user].params.sockets == 0) {
       emitter.emit('SIGUSER',user);
+      delete registry[user];
     }
   });
 });


### PR DESCRIPTION
Didn't include the event to delete registry entries after removing a user's container; this lead to some interesting socket hangups.