### PR TITLE
Registry identification

### DIFF
--- a/hub.js
+++ b/hub.js
@@ -176,8 +176,10 @@ server.get('/login', (req, res) => {
   // Create container from Docker API
   let district = directory[user].district;
   ishmael.run(`world:${process.env.IMAGE}`, [], undefined, {
-    'name': `${user}`,
-    'label': `${user}`,
+    //'name': `${user}`,
+    "Labels": {
+      "student":`${user}`
+    },
     "Hostname": "term-world",
     "Env": [
       `VS_USER=${user}`,
@@ -198,6 +200,7 @@ server.get('/login', (req, res) => {
     // On container launch error, report error
     if(err) {
       let code = err.statusCode;
+      console.log(err);
       if(code == 409) {
         let list = await ishmael.listContainers({label: user});
         emitter.emit('register',

--- a/hub.js
+++ b/hub.js
@@ -176,7 +176,6 @@ server.get('/login', (req, res) => {
   // Create container from Docker API
   let district = directory[user].district;
   ishmael.run(`world:${process.env.IMAGE}`, [], undefined, {
-    //'name': `${user}`,
     "Labels": {
       "student":`${user}`
     },
@@ -278,6 +277,12 @@ app.on('upgrade', (req, socket, head) => {
   let proxy = httpProxy.createServer({});
   session(req, {}, () => {
     user = req.session.user;
+    if(
+      user === undefined || 
+      registry[user] === undefined
+    ) { 
+      return res.redirect('/login'); 
+    }
     proxy.ws(req, socket, head, 
       {target: `http://localhost:${registry[user].params.port}/`}
     ); 


### PR DESCRIPTION
Adding some more emitter logic; removing unique name constraint, but replacing functionality with a `student` label. We can search containers by student label after this. For example:

```bash
docker ps --filter "label=student" --format "table {{.Names}}\t{{.Labels}}\t{{.Ports}}"
```