### PR TITLE
Fixing empty session header; troubleshooting container timeout errors

### DIFF
--- a/hub.js
+++ b/hub.js
@@ -254,6 +254,7 @@ app.on('upgrade', (req, socket, head) => {
   let proxy = httpProxy.createServer({});
   session(req, {}, () => {
     user = req.session.user;
+    if(user === undefined) { return; }
     proxy.ws(req, socket, head,
       {target: `http://localhost:${registry[user].params.port}/`}
     );
@@ -302,7 +303,6 @@ setInterval(() => {
       if(!interrupt) {
         registry[user].params.sockets--;
         if(registry[user].params.sockets == 0) {
-          console.log("Kills idlez ded.");
           emitter.emit('SIGUSER',user);
           delete registry[user];
         }


### PR DESCRIPTION
Hopefully fixing a gremlin that's been around for a while. If users stay connected after sockets have been closed and entries purged from the registry, the situation created a fatal flaw. The issue might have been `pm2` restarting often due to dropped/missed packets, which reset the timer every time.