### PR TITLE
Adding .env check for dynamic volume name

### DIFF
--- a/hub.js
+++ b/hub.js
@@ -181,7 +181,7 @@ server.get('/login', (req, res) => {
     ],
     "ExposedPorts": {"8000/tcp":{}},
     "HostConfig": {
-      "Binds": [`sum2022:/world`],
+      "Binds": [`${process.env.VOLUME}:/world`],
       "PortBindings": {
         "8000/tcp": [
           {


### PR DESCRIPTION
Volume from summer work was still in the main file; removed to a required .env valued called `VOLUME`