### PR TITLE
Adding final hub, Fall 2022; migrating to main branch

### DIFF
--- a/hub.js
+++ b/hub.js
@@ -218,7 +218,7 @@ const startContainer = (user) => {
       }
     }
   }, (err, data, container) => {
-    if (err.statusCode === 409) throw err;
+    // if (err.statusCode === 409) throw err;
   });
 }
 


### PR DESCRIPTION
This PR updates `main` to the working branch of `term-hub` that has been operating on world.* for the last few months. Now that the semester is over, I'm rolling it over to `main` to begin the process of releasing it and updating dependencies.