### PR TITLE
Updating to remove the socket destruction

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -352,7 +352,6 @@ app.on("upgrade", async (req, socket, head) => {
   });
   socket.on("close", () => {
     socket.end();
-    socket.destroy();
   });
 
   // Remove user from start queue


### PR DESCRIPTION
Adopting an either/or approach to socket closure; currently was `end`ing and `destroy`ing a socket at the same time. Does this prevent the socket from closing gracefully? I'm pretty sure it does.